### PR TITLE
Недостающие методы get-blocks и get-last-txs

### DIFF
--- a/src/task_handlers/task_handlers.cpp
+++ b/src/task_handlers/task_handlers.cpp
@@ -49,8 +49,10 @@ const std::map<std::pair<std::string, UseLocalDatabase>, handler_func> post_hand
     { std::pair<std::string, UseLocalDatabase>("fetch-history", true),              perform<fetch_history_handler_sync> }, // +
     { std::pair<std::string, UseLocalDatabase>("send-tx", true),                    perform<send_tx_handler_sync> }, // +
     { std::pair<std::string, UseLocalDatabase>("get-count-blocks", true),           perform<get_count_blocks_handler_sync> }, // +
+    { std::pair<std::string, UseLocalDatabase>("get-last-txs", true),               perform<get_last_txs_handler> },
     { std::pair<std::string, UseLocalDatabase>("get-block-by-hash", true),          perform<get_block_by_hash_handler_sync> }, // +
     { std::pair<std::string, UseLocalDatabase>("get-block-by-number", true),        perform<get_block_by_number_handler_sync> }, // +
+    { std::pair<std::string, UseLocalDatabase>("get-blocks", true),                 perform<get_blocks_handler> },
     { std::pair<std::string, UseLocalDatabase>("get-tx", true),                     perform<get_tx_handler_sync> }, // +
     { std::pair<std::string, UseLocalDatabase>("get-dump-block-by-hash", true),     perform<get_dump_block_by_hash_handler_sync> }, // +
     { std::pair<std::string, UseLocalDatabase>("get-dump-block-by-number", true),   perform<get_dump_block_by_number_handler_sync> }, // +


### PR DESCRIPTION
В readme.md они указаны как действующие и по факту работают, но в хендлерах не прописаны.

Сделал сначала issue https://github.com/metahashorg/metahash-fullnode-client/issues/9, потом проверил - если добавить то всё запускается как положено